### PR TITLE
chore: update WordPress tested version to 6.9

### DIFF
--- a/omnisend-for-lifterlms/class-omnisend-lifterlmsaddon.php
+++ b/omnisend-for-lifterlms/class-omnisend-lifterlmsaddon.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Omnisend for LifterLMS Add-On
  * Description: A LifterLMS add-on to sync contacts with Omnisend. In collaboration with LifterLMS plugin it enables better customer tracking
- * Version: 1.0.10
+ * Version: 1.0.11
  * Author: Omnisend
  * Author URI: https://www.omnisend.com
  * Developer: Omnisend
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'OMNISEND_LIFTERLMS_ADDON_NAME', 'Omnisend for Lifter LMS Add-On' );
-define( 'OMNISEND_LIFTERLMS_ADDON_VERSION', '1.0.10' );
+define( 'OMNISEND_LIFTERLMS_ADDON_VERSION', '1.0.11' );
 
 spl_autoload_register( array( 'Omnisend_LifterLMSAddOn', 'autoloader' ) );
 add_action( 'plugins_loaded', array( 'Omnisend_LifterLMSAddOn', 'check_plugin_requirements' ) );

--- a/omnisend-for-lifterlms/readme.txt
+++ b/omnisend-for-lifterlms/readme.txt
@@ -3,9 +3,9 @@ Plugin Name: Omnisend for LifterLMS Add-On
 Contributors: omnisend
 Tags: LifterLMS, form, email marketing, web tracking, subscriber collection
 Requires at least: 4.7.0
-Tested up to: 6.6
+Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.0.10
+Stable tag: 1.0.11
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -53,6 +53,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Convert more visitors with highly-targeted landing pages
 
 == Changelog ==
+
+= 1.0.11 =
+* Tested up to WordPress 6.9
 
 = 1.0.10 =
 * Update screenshots


### PR DESCRIPTION
## What?
Update WordPress tested version to 6.9 and bump plugin version to 1.0.11.

## Why?
Plugin has been tested with WordPress 6.9.